### PR TITLE
fix: TypeScript v6 対応のため tsconfig に ignoreDeprecations と rootDir を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -21,6 +22,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "newLine": "LF",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "Node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -22,12 +22,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
-    "newLine": "LF",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "newLine": "LF"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6 へのアップグレード（Renovate PR #2159）に伴い発生するコンパイルエラーに対応するため、`tsconfig.json` を修正しました。

## 変更内容

`tsconfig.json` の `compilerOptions` を以下のように変更しました。

| エラー | 対応内容 |
|---|---|
| `TS5107: 'moduleResolution=node10' is deprecated` | `moduleResolution: "Node"` → `"node16"` に変更 |
| `TS5101: 'baseUrl' is deprecated` | 未使用の `baseUrl: "."` および `paths` を削除 |
| `TS5011: 'rootDir' must be explicitly set` | `rootDir: "./src"` を追加 |

`module` も `"commonjs"` から `"node16"` に変更し、`moduleResolution` との整合性を確保しています。

## 変更ファイル

- `tsconfig.json`
  - `module`: `"commonjs"` → `"node16"`
  - `moduleResolution`: `"Node"` → `"node16"`
  - `rootDir: "./src"` を追加
  - 未使用の `baseUrl: "."` を削除
  - 未使用の `paths: { "@/*": ["src/*"] }` を削除

## 動作確認

- TypeScript 5.9.3（現行バージョン）: コンパイルエラーなし
- TypeScript 6.0.3（アップグレード後）: コンパイルエラーなし

## 補足

- `baseUrl` および `paths` の `@/*` エイリアスはソースコード内で使用されていないため、削除しても動作に影響はありません
- `ignoreDeprecations: "6.0"` は TypeScript 5.x では `TS5103` エラーになるため使用せず、非推奨設定を適切な代替設定に置き換えることで対応しました
- Renovate PR #2159 (`chore(deps): update dependency typescript to v6`) は直接変更しておらず、本 PR はそのアップグレードを通すための前提修正です

🤖 Generated with [Claude Code](https://claude.ai/code)