### PR TITLE
fix(lint): resolve eslint-plugin-unicorn violations for eslint-config v1.15.44

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,29 +1,37 @@
 import { Client, GatewayIntentBits, ThreadChannel } from 'discord.js'
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 
 export class Discord {
-  private config: Configuration
+  private config: Config
   public readonly client: Client
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     const logger = Logger.configure('Discord.constructor')
     this.client = new Client({
       intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
     })
     this.client.on('ready', this.onReady.bind(this))
     this.client.on('threadCreate', (thread) => {
-      this.onThreadCreate(thread).catch((error: unknown) => {
-        logger.error('❌ Failed to handle threadCreate event', error as Error)
-      })
+      ;(async () => {
+        try {
+          await this.onThreadCreate(thread)
+        } catch (error: unknown) {
+          logger.error('❌ Failed to handle threadCreate event', error as Error)
+        }
+      })()
     })
 
     this.config = config
 
-    this.client.login(config.get('discord').token).catch((error: unknown) => {
-      const logger = Logger.configure('Discord.constructor')
-      logger.error('❌ Failed to login', error as Error)
-    })
+    const client = this.client
+    ;(async () => {
+      try {
+        await client.login(config.get('discord').token)
+      } catch (error: unknown) {
+        logger.error('❌ Failed to login', error as Error)
+      }
+    })()
   }
 
   public getClient() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Discord } from './discord'
 
 function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')
@@ -17,16 +17,16 @@ function main() {
   logger.info('🤖 Starting discord-new-threads')
   const discord = new Discord(config)
   process.once('SIGINT', () => {
-    logger.info('👋 SIGINT signal received.')
-    discord
-      .close()
-      .then(() => {
+    ;(async () => {
+      logger.info('👋 SIGINT signal received.')
+      try {
+        await discord.close()
         process.exit(0)
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         logger.error('❌ Failed to close', error as Error)
         process.exit(1)
-      })
+      }
+    })()
   })
 }
 


### PR DESCRIPTION
## What
Renovate PR #2334 (`@book000/eslint-config` 1.15.4 -> 1.15.44) fails CI because the bump pulls in a newer `eslint-plugin-unicorn` that flags 7 pre-existing style issues:

- `unicorn/name-replacements`: `Configuration` class -> renamed to `Config` (config.ts, discord.ts, main.ts)
- `unicorn/prefer-await`: `.then()`/`.catch()` promise chaining -> converted to `await` inside `try`/`catch`, wrapped in self-invoking async functions where needed (discord.ts's threadCreate handler and login call, main.ts's SIGINT handler)

No behavior change intended.

## Verification
- Locally bumped `@book000/eslint-config` to 1.15.44 and confirmed `pnpm run lint` (prettier + eslint + tsc) passes clean.
- Reverted to the original pinned 1.15.4 and confirmed `pnpm run lint` still passes (no regression).

## Related
Fixes the CI failure blocking #2334.